### PR TITLE
Add sequential options which allows process files one after another

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,6 +103,14 @@ module.exports = function(grunt) {
                 },
                 src: 'test/fixtures/a.scss',
                 dest: 'tmp/noWriteDest.scss'
+            },
+            sequential: {
+                options: {
+                    syntax: require('postcss-scss'),
+                    sequential: true
+                },
+                src: ['test/fixtures/a.scss', 'test/fixtures/a.css'],
+                dest: 'tmp/sequential.css'
             }
         },
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ options: {
 ```
 You can also specify a path where you want the file to be saved.
 
+#### options.sequential
+Type: `Boolean`
+Default value: `false`
+
+By default grunt-postcss will load all passed CSS files and immediately process them. Set this to `true` if you want files to be processed one by one. 
+This can help in case when you have a lot of CSS files and processing them causes an `out of memory` error.
+
 #### options.failOnError
 Type: `Boolean`
 Default value: `false`

--- a/test/test.js
+++ b/test/test.js
@@ -133,4 +133,12 @@ exports.gruntPostcss = {
         test.ok(!grunt.file.exists('tmp/noWriteDest.scss'));
         test.done();
     },
+
+    sequential: function(test) {
+        test.ok(grunt.file.exists('tmp/sequential.css'));
+        var actual = grunt.file.read('tmp/sequential.css');
+        var expected = grunt.file.read('test/fixtures/a.css');
+        test.strictEqual(actual, expected);
+        test.done();
+    },
 };


### PR DESCRIPTION
Hi!

Using grunt-postcss on a big project with a lot of CSS files (about 130 CSS files with 40MB total size) could cause memory out the problem because of running processors in async mode.

This PR contains the possibility to switch that mode to sync - so CSS files would be processed one after another, sequentially. It also saves a lot of RAM - GC will correctly find and kill that already processed files stuffs (source code, result object etc).

By default, this option set to false, so nothing will be changed for projects already using it.

P.S. Moved from original repo (https://github.com/nDmitry/grunt-postcss/pull/105) because it is abandoned.