### PR TITLE
Fix logging of source map output

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -200,7 +200,7 @@ module.exports = (grunt) => {
                         }
 
                         grunt.file.write(mapDest, result.map.toString());
-                        console.log(`>> File \x1b[36m%s\x1b[0m created (source map).`, dest.map);
+                        console.log(`>> File \x1b[36m%s\x1b[0m created (source map).`, `${dest}.map`);
 
                         tally.maps += 1;
                     }


### PR DESCRIPTION
This broke in commit 1c922daba218b49d30c946cfb68cde7c9aed516b because `${dest}.map` was replaced with `dest.map`.

This bug causes output like:

```
>> File Css/documentfooter.min.css created. 344.7 kB → 337.64 kB
>> File undefined created (source map).
```
