### PR TITLE
Added new option onError

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -247,7 +247,7 @@ module.exports = (grunt) => {
             done();
         }).catch((error) => {
             
-            if(options.onError != undefined && typeof options.onError === 'function'){
+            if (options.onError !== undefined && typeof options.onError === 'function') {
                 options.onError(error);
             }
             

--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -246,6 +246,11 @@ module.exports = (grunt) => {
 
             done();
         }).catch((error) => {
+            
+            if(options.onError != undefined && typeof options.onError === 'function'){
+                options.onError(error);
+            }
+            
             if (error.name === 'CssSyntaxError') {
                 grunt.fail.fatal(error.message + error.showSourceCode());
             } else {


### PR DESCRIPTION

Hi @C-Lodder !

If you don't like  `grunt.event.emit('grunt-postcss-error', error);`  look please the new option `onError`

This is needed to access errors from `postcss`

Thank you.